### PR TITLE
Adding a feature to control default print-object behavior.

### DIFF
--- a/src/dynamic-mixins.lisp
+++ b/src/dynamic-mixins.lisp
@@ -14,15 +14,6 @@
               (or (class-name o) 'mixin-class)
               (mapcar #'class-name classes)))))
 
-(defclass mixin-object () ())
-#-disable-mixin-object-print-object(defmethod print-object ((o mixin-object) s)
-  (let ((c (class-of o)))
-    (with-slots (classes) c
-      (print-unreadable-object (o s :identity t)
-        (format s "~S ~S"
-                (or (class-name c) 'mixin-object)
-                (mapcar #'class-name classes))))))
-
 (defstruct mix-list (list nil))
 
 (defun %find-class (name-or-class)

--- a/src/dynamic-mixins.lisp
+++ b/src/dynamic-mixins.lisp
@@ -15,7 +15,7 @@
               (mapcar #'class-name classes)))))
 
 (defclass mixin-object () ())
-(defmethod print-object ((o mixin-object) s)
+#-disable-mixin-object-print-object(defmethod print-object ((o mixin-object) s)
   (let ((c (class-of o)))
     (with-slots (classes) c
       (print-unreadable-object (o s :identity t)


### PR DESCRIPTION
Added a macro reader that can disable the creation of a PRINT-OBJECT method for MIXIN-OBJECT.  This allows for other mixin classes to have usable PRINT-OBJECT methods, since the MIXIN-OBJECT is often the most specific class for the PRINT-OBJECT method.

I use the macro reader by placing the following at the head of an asdf file that :DEPENDS-ON dynamic-mixins:

    (pushnew :disable-mixin-object-print-object cl:*features*)

Others might find this a useful feature.
Thanks,
Elliott 